### PR TITLE
Fix 'Hordes' typo and add Unity builds page

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
                                         <ul class="menu-area-main">
                                             <li class="active"> <a href="#top">Company</a> </li>
                                             <li> <a href="#games">Games</a> </li>
+                                            <li><a href="practicas/PI/index.html">Unity WebGL Builds</a></li>
 											
                                             <li> <a href="#privacy">Privacy Policy</a> </li>
 											<!--
@@ -166,7 +167,7 @@
 
                             <div class="Games">
                                 <h3>AR Zombie Fest</h3>
-                                <p>Enter The Realm of an Augmented Reality Random Generated 2D/3D Zombie Apocalypse and try to survive the Ordes of Undead Enemies as long as you can</p>
+                                <p>Enter The Realm of an Augmented Reality Random Generated 2D/3D Zombie Apocalypse and try to survive the Hordes of Undead Enemies as long as you can</p>
                                 <a href="https://play.google.com/store/apps/details?id=com.Trixelab.ARZombieFest">Free Download at Google Play</a>
                             </div>
                         </div>

--- a/practicas/PI/index.html
+++ b/practicas/PI/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Unity WebGL Builds</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 1em; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 0.5em 0; }
+    a { text-decoration: none; color: #0a66c2; }
+  </style>
+</head>
+<body>
+  <h1>Unity WebGL Builds</h1>
+  <ul>
+    <li><a href="../1_PI/3Dto2D/index.html">HUDs_Test_01 (3Dto2D)</a></li>
+    <li><a href="../1_PI/3Dto2D_V2/index.html">HUDs_Test_01 (3Dto2D_V2)</a></li>
+    <li><a href="../1_PI/demo/index.html">LenguajeTest (Demo)</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix a typo in the AR Zombie Fest description
- add a page linking Unity WebGL builds in `practicas/PI`
- link the new page from the main navigation menu

## Testing
- `npx -y htmlhint index.html` *(fails: Tag must be paired)*
- `npx -y htmlhint practicas/PI/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68401e8840ec833098ddbc3ea051d21c