### PR TITLE
Update Naranjas Del Turia imagery to orange grove theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1014,7 +1014,7 @@
      transition: 0s;
 }
 .header-top {
-    background: url(../images/banner2.png);
+    background: url(../images/header-orange-grove.svg);
     background-size: cover;
     background-repeat: no-repeat;
     padding-bottom: 50px;

--- a/images/header-orange-grove.svg
+++ b/images/header-orange-grove.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8fd3f4" />
+      <stop offset="100%" stop-color="#ffffff" />
+    </linearGradient>
+    <linearGradient id="field" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9ccc65" />
+      <stop offset="100%" stop-color="#558b2f" />
+    </linearGradient>
+    <linearGradient id="tree" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4caf50" />
+      <stop offset="100%" stop-color="#2e7d32" />
+    </linearGradient>
+    <linearGradient id="trunk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8d6e63" />
+      <stop offset="100%" stop-color="#5d4037" />
+    </linearGradient>
+    <radialGradient id="orange" cx="0.3" cy="0.3" r="0.9">
+      <stop offset="0%" stop-color="#ffe082" />
+      <stop offset="55%" stop-color="#ffb300" />
+      <stop offset="100%" stop-color="#ef6c00" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#sky)" />
+  <g transform="translate(0,420)">
+    <rect width="1600" height="480" fill="url(#field)" />
+    <path d="M0 300 C200 240 400 240 600 300 S1000 360 1200 300 S1600 240 1600 240 L1600 480 L0 480 Z" fill="#7cb342" opacity="0.7" />
+    <path d="M0 380 C200 320 400 320 600 380 S1000 440 1200 380 S1600 320 1600 320 L1600 480 L0 480 Z" fill="#558b2f" opacity="0.5" />
+  </g>
+  <g transform="translate(120,420)">
+    <g transform="translate(0,0)">
+      <rect x="-10" y="200" width="20" height="120" fill="url(#trunk)" />
+      <circle cx="0" cy="180" r="100" fill="url(#tree)" />
+    </g>
+    <g transform="translate(220,40)">
+      <rect x="-10" y="220" width="20" height="120" fill="url(#trunk)" />
+      <circle cx="0" cy="200" r="110" fill="url(#tree)" />
+    </g>
+    <g transform="translate(480,-10)">
+      <rect x="-12" y="240" width="24" height="140" fill="url(#trunk)" />
+      <circle cx="0" cy="210" r="130" fill="url(#tree)" />
+    </g>
+    <g transform="translate(780,30)">
+      <rect x="-10" y="220" width="20" height="130" fill="url(#trunk)" />
+      <circle cx="0" cy="200" r="115" fill="url(#tree)" />
+    </g>
+    <g transform="translate(1040,-20)">
+      <rect x="-10" y="240" width="20" height="140" fill="url(#trunk)" />
+      <circle cx="0" cy="205" r="135" fill="url(#tree)" />
+    </g>
+  </g>
+  <g transform="translate(200,520)" opacity="0.9">
+    <g transform="translate(0,0)">
+      <circle cx="0" cy="0" r="32" fill="url(#orange)" />
+      <circle cx="70" cy="10" r="30" fill="url(#orange)" />
+      <circle cx="140" cy="-5" r="34" fill="url(#orange)" />
+      <circle cx="210" cy="8" r="28" fill="url(#orange)" />
+      <circle cx="280" cy="-2" r="33" fill="url(#orange)" />
+    </g>
+    <g transform="translate(30,80)">
+      <circle cx="0" cy="0" r="32" fill="url(#orange)" />
+      <circle cx="70" cy="-12" r="30" fill="url(#orange)" />
+      <circle cx="140" cy="4" r="34" fill="url(#orange)" />
+      <circle cx="210" cy="-10" r="30" fill="url(#orange)" />
+      <circle cx="280" cy="6" r="33" fill="url(#orange)" />
+    </g>
+    <g transform="translate(60,150)">
+      <circle cx="0" cy="0" r="32" fill="url(#orange)" />
+      <circle cx="70" cy="-12" r="30" fill="url(#orange)" />
+      <circle cx="140" cy="4" r="34" fill="url(#orange)" />
+      <circle cx="210" cy="-10" r="30" fill="url(#orange)" />
+      <circle cx="280" cy="6" r="33" fill="url(#orange)" />
+    </g>
+  </g>
+  <g transform="translate(1020,540)" opacity="0.7">
+    <g transform="translate(0,0)">
+      <circle cx="0" cy="0" r="30" fill="url(#orange)" />
+      <circle cx="60" cy="-4" r="30" fill="url(#orange)" />
+      <circle cx="120" cy="4" r="28" fill="url(#orange)" />
+      <circle cx="180" cy="-6" r="32" fill="url(#orange)" />
+    </g>
+    <g transform="translate(30,70)">
+      <circle cx="0" cy="0" r="30" fill="url(#orange)" />
+      <circle cx="60" cy="-8" r="28" fill="url(#orange)" />
+      <circle cx="120" cy="6" r="30" fill="url(#orange)" />
+      <circle cx="180" cy="-4" r="32" fill="url(#orange)" />
+    </g>
+  </g>
+</svg>

--- a/images/hero-orange-crate.svg
+++ b/images/hero-orange-crate.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 700" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5f9ff" />
+      <stop offset="100%" stop-color="#e0f2f1" />
+    </linearGradient>
+    <linearGradient id="crate" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#d7ccc8" />
+      <stop offset="100%" stop-color="#8d6e63" />
+    </linearGradient>
+    <linearGradient id="crateHighlight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#bcaaa4" />
+      <stop offset="100%" stop-color="#6d4c41" />
+    </linearGradient>
+    <radialGradient id="orangeFruit" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#fff3e0" />
+      <stop offset="60%" stop-color="#ffb74d" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </radialGradient>
+    <linearGradient id="leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#aed581" />
+      <stop offset="100%" stop-color="#388e3c" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="700" fill="url(#background)" />
+  <g transform="translate(150,140)">
+    <rect x="0" y="260" width="600" height="180" rx="40" ry="40" fill="rgba(0,0,0,0.08)" />
+    <g transform="translate(0,80)">
+      <rect x="30" y="120" width="540" height="200" rx="30" fill="url(#crate)" />
+      <rect x="30" y="120" width="540" height="60" fill="url(#crateHighlight)" opacity="0.8" />
+      <rect x="30" y="200" width="540" height="60" fill="url(#crateHighlight)" opacity="0.85" />
+      <rect x="30" y="280" width="540" height="40" fill="url(#crateHighlight)" opacity="0.9" />
+      <g stroke="#6d4c41" stroke-width="8" opacity="0.6">
+        <line x1="110" y1="120" x2="110" y2="320" />
+        <line x1="190" y1="120" x2="190" y2="320" />
+        <line x1="270" y1="120" x2="270" y2="320" />
+        <line x1="350" y1="120" x2="350" y2="320" />
+        <line x1="430" y1="120" x2="430" y2="320" />
+        <line x1="510" y1="120" x2="510" y2="320" />
+      </g>
+      <rect x="30" y="120" width="540" height="200" rx="30" fill="none" stroke="#5d4037" stroke-width="10" opacity="0.7" />
+    </g>
+    <g transform="translate(120,0)">
+      <g transform="translate(0,160)">
+        <circle cx="0" cy="0" r="90" fill="url(#orangeFruit)" />
+        <ellipse cx="-30" cy="-80" rx="35" ry="14" fill="rgba(255,255,255,0.6)" />
+        <path d="M-20 -90 C 0 -110 30 -110 40 -90" fill="url(#leaf)" />
+      </g>
+      <g transform="translate(140,140)">
+        <circle cx="0" cy="0" r="100" fill="url(#orangeFruit)" />
+        <ellipse cx="-40" cy="-90" rx="38" ry="16" fill="rgba(255,255,255,0.5)" />
+        <path d="M-35 -95 C -10 -130 40 -130 70 -95" fill="url(#leaf)" />
+      </g>
+      <g transform="translate(310,180)">
+        <circle cx="0" cy="0" r="92" fill="url(#orangeFruit)" />
+        <ellipse cx="-32" cy="-82" rx="34" ry="14" fill="rgba(255,255,255,0.45)" />
+        <path d="M-20 -92 C 10 -122 40 -122 60 -96" fill="url(#leaf)" />
+      </g>
+      <g transform="translate(220,60)">
+        <circle cx="0" cy="0" r="82" fill="url(#orangeFruit)" />
+        <ellipse cx="-28" cy="-70" rx="30" ry="12" fill="rgba(255,255,255,0.4)" />
+        <path d="M-26 -78 C -6 -102 24 -104 48 -84" fill="url(#leaf)" />
+      </g>
+      <g transform="translate(420,120)">
+        <circle cx="0" cy="0" r="85" fill="url(#orangeFruit)" />
+        <ellipse cx="-26" cy="-78" rx="30" ry="12" fill="rgba(255,255,255,0.4)" />
+        <path d="M-22 -86 C -2 -110 30 -110 56 -90" fill="url(#leaf)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/logo-naranjas.svg
+++ b/images/logo-naranjas.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <linearGradient id="logoOrange" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffe082" />
+      <stop offset="50%" stop-color="#ffb74d" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </linearGradient>
+    <linearGradient id="logoLeaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#a5d6a7" />
+      <stop offset="100%" stop-color="#2e7d32" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="120" rx="24" ry="24" fill="#ffffff" opacity="0.0" />
+  <g transform="translate(40,18)">
+    <circle cx="42" cy="42" r="38" fill="url(#logoOrange)" />
+    <path d="M36 10 C 44 -2 62 -2 70 10" fill="url(#logoLeaf)" />
+    <text x="100" y="46" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="38" fill="#2c3e50" font-weight="700">Naranjas</text>
+    <text x="100" y="82" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="32" fill="#f57c00" font-weight="600">del Turia</text>
+  </g>
+</svg>

--- a/images/orange-grove-close.svg
+++ b/images/orange-grove-close.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <linearGradient id="groveSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a3d5ff" />
+      <stop offset="100%" stop-color="#e8f5e9" />
+    </linearGradient>
+    <linearGradient id="groveGround" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c5e1a5" />
+      <stop offset="100%" stop-color="#81c784" />
+    </linearGradient>
+    <linearGradient id="treeCanopy" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#66bb6a" />
+      <stop offset="100%" stop-color="#2e7d32" />
+    </linearGradient>
+    <linearGradient id="treeTrunk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a1887f" />
+      <stop offset="100%" stop-color="#6d4c41" />
+    </linearGradient>
+    <radialGradient id="groveOrange" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#fff8e1" />
+      <stop offset="60%" stop-color="#ffb74d" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </radialGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#groveSky)" />
+  <path d="M0 360 C 150 300 250 300 400 360 C 550 420 650 420 800 360 L800 600 L0 600 Z" fill="url(#groveGround)" />
+  <g transform="translate(80,260)">
+    <g transform="translate(0,0)">
+      <rect x="-15" y="120" width="30" height="130" fill="url(#treeTrunk)" />
+      <circle cx="0" cy="90" r="110" fill="url(#treeCanopy)" />
+    </g>
+    <g transform="translate(200,-20)">
+      <rect x="-15" y="160" width="30" height="150" fill="url(#treeTrunk)" />
+      <circle cx="0" cy="120" r="130" fill="url(#treeCanopy)" />
+    </g>
+    <g transform="translate(420,10)">
+      <rect x="-15" y="140" width="30" height="140" fill="url(#treeTrunk)" />
+      <circle cx="0" cy="110" r="120" fill="url(#treeCanopy)" />
+    </g>
+    <g transform="translate(600,-30)">
+      <rect x="-15" y="170" width="30" height="150" fill="url(#treeTrunk)" />
+      <circle cx="0" cy="130" r="135" fill="url(#treeCanopy)" />
+    </g>
+  </g>
+  <g transform="translate(120,340)">
+    <g transform="translate(0,0)" opacity="0.92">
+      <circle cx="0" cy="0" r="28" fill="url(#groveOrange)" />
+      <circle cx="30" cy="-18" r="24" fill="url(#groveOrange)" />
+      <circle cx="-30" cy="-12" r="26" fill="url(#groveOrange)" />
+    </g>
+    <g transform="translate(180,-10)" opacity="0.88">
+      <circle cx="0" cy="0" r="30" fill="url(#groveOrange)" />
+      <circle cx="36" cy="-14" r="26" fill="url(#groveOrange)" />
+      <circle cx="-34" cy="-16" r="28" fill="url(#groveOrange)" />
+      <circle cx="10" cy="24" r="26" fill="url(#groveOrange)" />
+    </g>
+    <g transform="translate(360,20)" opacity="0.85">
+      <circle cx="0" cy="0" r="32" fill="url(#groveOrange)" />
+      <circle cx="40" cy="-20" r="28" fill="url(#groveOrange)" />
+      <circle cx="-36" cy="-18" r="28" fill="url(#groveOrange)" />
+      <circle cx="12" cy="26" r="26" fill="url(#groveOrange)" />
+    </g>
+  </g>
+  <g transform="translate(80,450)" opacity="0.6">
+    <ellipse cx="120" cy="0" rx="100" ry="20" fill="#9ccc65" />
+    <ellipse cx="340" cy="10" rx="110" ry="24" fill="#81c784" />
+    <ellipse cx="560" cy="0" rx="90" ry="20" fill="#66bb6a" />
+  </g>
+</svg>

--- a/images/orange-harvest-baskets.svg
+++ b/images/orange-harvest-baskets.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 600" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <linearGradient id="harvestSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f8e9" />
+      <stop offset="100%" stop-color="#fffde7" />
+    </linearGradient>
+    <linearGradient id="harvestField" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aed581" />
+      <stop offset="100%" stop-color="#7cb342" />
+    </linearGradient>
+    <linearGradient id="basket" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f3e5ab" />
+      <stop offset="100%" stop-color="#b68d40" />
+    </linearGradient>
+    <radialGradient id="harvestOrange" cx="0.35" cy="0.3" r="0.85">
+      <stop offset="0%" stop-color="#fff8e1" />
+      <stop offset="65%" stop-color="#ffb74d" />
+      <stop offset="100%" stop-color="#ef6c00" />
+    </radialGradient>
+    <linearGradient id="leafHarvest" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9ccc65" />
+      <stop offset="100%" stop-color="#2e7d32" />
+    </linearGradient>
+  </defs>
+  <rect width="820" height="600" fill="url(#harvestSky)" />
+  <path d="M0 360 C 200 300 340 320 540 360 C 660 384 740 380 820 360 L820 600 L0 600 Z" fill="url(#harvestField)" />
+  <g transform="translate(120,300)">
+    <ellipse cx="130" cy="200" rx="140" ry="40" fill="rgba(0,0,0,0.12)" />
+    <ellipse cx="430" cy="200" rx="140" ry="36" fill="rgba(0,0,0,0.1)" />
+    <g transform="translate(0,0)">
+      <path d="M30 60 h200 a30 30 0 0 1 30 30 v80 a60 60 0 0 1 -60 60 h-170 a30 30 0 0 1 -30 -30 v-80 a60 60 0 0 1 60 -60z" fill="url(#basket)" stroke="#8d6e63" stroke-width="8" opacity="0.95" />
+      <g transform="translate(60,40)">
+        <circle cx="0" cy="0" r="36" fill="url(#harvestOrange)" />
+        <path d="M-18 -30 C 0 -46 32 -44 44 -26" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(130,26)">
+        <circle cx="0" cy="0" r="40" fill="url(#harvestOrange)" />
+        <path d="M-22 -32 C 0 -56 40 -54 58 -32" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(190,44)">
+        <circle cx="0" cy="0" r="34" fill="url(#harvestOrange)" />
+        <path d="M-18 -30 C 0 -50 34 -48 48 -28" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(90,80)">
+        <circle cx="0" cy="0" r="32" fill="url(#harvestOrange)" />
+      </g>
+      <g transform="translate(150,100)">
+        <circle cx="0" cy="0" r="30" fill="url(#harvestOrange)" />
+      </g>
+      <g transform="translate(210,90)">
+        <circle cx="0" cy="0" r="28" fill="url(#harvestOrange)" />
+      </g>
+    </g>
+    <g transform="translate(300,10)">
+      <path d="M30 60 h200 a30 30 0 0 1 30 30 v80 a60 60 0 0 1 -60 60 h-170 a30 30 0 0 1 -30 -30 v-80 a60 60 0 0 1 60 -60z" fill="url(#basket)" stroke="#8d6e63" stroke-width="8" opacity="0.9" />
+      <g transform="translate(60,40)">
+        <circle cx="0" cy="0" r="36" fill="url(#harvestOrange)" />
+        <path d="M-18 -30 C 0 -46 32 -44 44 -26" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(120,26)">
+        <circle cx="0" cy="0" r="38" fill="url(#harvestOrange)" />
+        <path d="M-20 -32 C 4 -54 40 -54 56 -34" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(180,44)">
+        <circle cx="0" cy="0" r="34" fill="url(#harvestOrange)" />
+        <path d="M-18 -30 C 0 -50 34 -48 48 -28" fill="url(#leafHarvest)" />
+      </g>
+      <g transform="translate(90,78)">
+        <circle cx="0" cy="0" r="32" fill="url(#harvestOrange)" />
+      </g>
+      <g transform="translate(150,98)">
+        <circle cx="0" cy="0" r="30" fill="url(#harvestOrange)" />
+      </g>
+      <g transform="translate(210,88)">
+        <circle cx="0" cy="0" r="28" fill="url(#harvestOrange)" />
+      </g>
+    </g>
+  </g>
+  <g transform="translate(520,180)" opacity="0.7">
+    <path d="M0 0 C 40 -20 80 -20 120 0" stroke="#f57c00" stroke-width="10" fill="none" stroke-linecap="round" />
+    <path d="M20 20 C 60 0 100 0 140 20" stroke="#f9a825" stroke-width="8" fill="none" stroke-linecap="round" />
+    <path d="M40 40 C 80 20 120 20 160 40" stroke="#ffcc80" stroke-width="6" fill="none" stroke-linecap="round" />
+  </g>
+</svg>

--- a/images/privacy-grove.svg
+++ b/images/privacy-grove.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 520" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <linearGradient id="privacySky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d1f1ff" />
+      <stop offset="100%" stop-color="#f1f8e9" />
+    </linearGradient>
+    <linearGradient id="privacyField" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c8e6c9" />
+      <stop offset="100%" stop-color="#81c784" />
+    </linearGradient>
+    <linearGradient id="privacyPath" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffe0b2" />
+      <stop offset="100%" stop-color="#ffcc80" />
+    </linearGradient>
+    <linearGradient id="privacyTree" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#66bb6a" />
+      <stop offset="100%" stop-color="#2e7d32" />
+    </linearGradient>
+    <linearGradient id="privacyTrunk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8d6e63" />
+      <stop offset="100%" stop-color="#5d4037" />
+    </linearGradient>
+    <radialGradient id="privacyOrange" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#fff3e0" />
+      <stop offset="60%" stop-color="#ffb74d" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </radialGradient>
+  </defs>
+  <rect width="780" height="520" fill="url(#privacySky)" />
+  <path d="M0 320 C 180 260 320 280 480 330 C 600 366 700 360 780 330 L780 520 L0 520 Z" fill="url(#privacyField)" />
+  <path d="M340 520 C 320 400 380 320 440 260 C 480 220 520 200 580 170" fill="none" stroke="url(#privacyPath)" stroke-width="60" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+  <g transform="translate(120,220)">
+    <g>
+      <rect x="-18" y="130" width="36" height="140" fill="url(#privacyTrunk)" />
+      <circle cx="0" cy="90" r="120" fill="url(#privacyTree)" />
+    </g>
+    <g transform="translate(200,-40)">
+      <rect x="-18" y="180" width="36" height="160" fill="url(#privacyTrunk)" />
+      <circle cx="0" cy="130" r="150" fill="url(#privacyTree)" />
+    </g>
+    <g transform="translate(420,-10)">
+      <rect x="-18" y="150" width="36" height="150" fill="url(#privacyTrunk)" />
+      <circle cx="0" cy="120" r="135" fill="url(#privacyTree)" />
+    </g>
+  </g>
+  <g transform="translate(120,340)">
+    <g opacity="0.9">
+      <circle cx="0" cy="0" r="28" fill="url(#privacyOrange)" />
+      <circle cx="-32" cy="-16" r="26" fill="url(#privacyOrange)" />
+      <circle cx="28" cy="-20" r="30" fill="url(#privacyOrange)" />
+      <circle cx="12" cy="26" r="24" fill="url(#privacyOrange)" />
+    </g>
+    <g transform="translate(210,-10)" opacity="0.85">
+      <circle cx="0" cy="0" r="30" fill="url(#privacyOrange)" />
+      <circle cx="-36" cy="-18" r="26" fill="url(#privacyOrange)" />
+      <circle cx="30" cy="-14" r="28" fill="url(#privacyOrange)" />
+      <circle cx="10" cy="26" r="26" fill="url(#privacyOrange)" />
+    </g>
+    <g transform="translate(420,10)" opacity="0.8">
+      <circle cx="0" cy="0" r="32" fill="url(#privacyOrange)" />
+      <circle cx="-34" cy="-16" r="28" fill="url(#privacyOrange)" />
+      <circle cx="30" cy="-10" r="30" fill="url(#privacyOrange)" />
+      <circle cx="12" cy="28" r="26" fill="url(#privacyOrange)" />
+    </g>
+  </g>
+  <g transform="translate(520,150)" opacity="0.4">
+    <circle cx="0" cy="0" r="120" fill="#ffffff" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                             <div class="full">
                                 <div class="center-desk">
                                     <div class="logo">
-                                        <a href="index.html"><img src="images/logo.png" alt="#" /></a>
+                                        <a href="index.html"><img src="images/logo-naranjas.svg" alt="Naranjas del Turia" /></a>
                                     </div>
                                 </div>
                             </div>
@@ -111,7 +111,7 @@
                             </div>
                              <div class="col-xl-6 col-lg-6 col-md-6 col-sm-12 ">
                                 <div class="text-img">
-                                   <figure><img src="images/img.png" alt="#"/></figure>
+                                   <figure><img src="images/hero-orange-crate.svg" alt="Cesta de naranjas frescas"/></figure>
                                 </div>
                             </div>
 
@@ -140,7 +140,7 @@
 
                         <div class="col-xl-4 col-lg-4 col-md-4 col-sm-12">
                             <div class="two-box">
-                                <figure><img src="images/tnfc.png" alt="#" /></figure>
+                                <figure><img src="images/orange-harvest-baskets.svg" alt="Cosecha de naranjas en cajas" /></figure>
                             </div>
                         </div>
 
@@ -159,7 +159,7 @@
 
                         <div class="col-xl-4 col-lg-4 col-md-4 col-sm-12">
                             <div class="two-box">
-                                <figure><img src="images/ARZF.png" alt="#" /></figure>
+                                <figure><img src="images/orange-grove-close.svg" alt="Campo de naranjos al atardecer" /></figure>
                             </div>
                         </div>
 
@@ -231,7 +231,7 @@
 
                         <div class="col-xl-4 col-lg-4 col-md-4 col-sm-12">
                             <div class="two-box">
-                                <figure><img src="images/privacy_2.png" alt="#" /></figure>
+                                <figure><img src="images/privacy-grove.svg" alt="Sendero entre campos de naranjos" /></figure>
                             </div>
                         </div>
 
@@ -463,7 +463,7 @@
                                         <li><a href="#"><img src="icon/lin(2).png"></a></li>
                                          <li><a href="#"><img src="icon/instagram.png"></a></li>
                                     </ul>
-                                    <a href="index.html"> <img src="images/logo.png" alt="logo"></a>
+                                    <a href="index.html"> <img src="images/logo-naranjas.svg" alt="Naranjas del Turia"></a>
                                 </div>
 								
                             </div>


### PR DESCRIPTION
## Summary
- replace hero, section, and privacy imagery with custom SVG illustrations featuring oranges and groves
- update the site logo and header background to match the new Naranjas del Turia visual identity
- refresh HTML alt text to describe the new orange-focused artwork

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68de96802df883308fb33d383613f220