### PR TITLE
Actualiza imágenes de NaranjasDelTuria con temática de naranjos

### DIFF
--- a/proyectos/NaranjasDelTuria/agricultor.html
+++ b/proyectos/NaranjasDelTuria/agricultor.html
@@ -25,7 +25,7 @@
 
 <main class="container">
 <h2 class="section-title">El Agricultor</h2>
-<img src="https://images.unsplash.com/photo-1617093727343-374698b1b08f?q=80&w=1200&auto=format&fit=crop" alt="" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
+<img src="https://cdn.pixabay.com/photo/2016/09/12/03/22/orange-tree-1668673_1280.jpg" alt="Agricultor en un campo de naranjos" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
 <p>Soy Amalio García, agricultor en Paterna (Camp del Túria). Regamos por la acequia de Moncada y recolectamos a mano. Desde 2010 ofrecemos nuestras naranjas directamente al consumidor.</p>
 <p>Respetamos el medio ambiente, la calidad y el trato cercano. Gracias por confiar en Naranjas del Túria.</p>
 </main>

--- a/proyectos/NaranjasDelTuria/faq.html
+++ b/proyectos/NaranjasDelTuria/faq.html
@@ -26,27 +26,27 @@
 <main class="container">
 <h2 class="section-title">Preguntas Frecuentes</h2>
 <div class="grid cards">
-  <article class="card"><img src="https://images.unsplash.com/photo-1534088568595-a066f410bcda?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/01/13/11/45/orange-1970895_1280.jpg" alt="Naranjas maduras en el árbol"><div class="pad">
     <h3>¿Las naranjas son recogidas del árbol?</h3>
     <p>Sí, en su mejor punto. Sin almacén ni cámaras, ni tratamientos de brillo.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1547514701-42782101795e?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/10/20/20/49/orange-2870318_1280.jpg" alt="Detalle de naranjas cosechadas"><div class="pad">
     <h3>¿Diferencia entre mesa y zumo?</h3>
     <p>El tamaño/estética de la piel; la calidad de la fruta es la misma.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1542444459-db63c9f73396?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/06/03/21/44/oranges-2367029_1280.jpg" alt="Cajas de naranjas listas para enviar"><div class="pad">
     <h3>¿Cómo conservarlas?</h3>
     <p>Fuera de la caja, en lugar fresco y seco, sin amontonarlas.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1617093727343-374698b1b08f?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2016/02/19/10/00/orange-1209417_1280.jpg" alt="Surco de naranjos en el campo"><div class="pad">
     <h3>¿Se puede elegir hora?</h3>
     <p>Se elige el día. La hora depende de la ruta del transportista.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1534088568595-a066f410bcda?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/05/04/17/19/orange-2283942_1280.jpg" alt="Mano recogiendo naranjas del árbol"><div class="pad">
     <h3>¿Y si llueve?</h3>
     <p>No recolectamos con lluvia. Avisamos y reprogramamos envío.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1606768666853-403c90a981ad?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2015/09/09/17/24/orange-932966_1280.jpg" alt="Caja de naranjas preparada para envío"><div class="pad">
     <h3>Gastos incluidos</h3>
     <p>Transporte incluido. Contra reembolso +2,5€ (gestión opcional).</p>
   </div></article>

--- a/proyectos/NaranjasDelTuria/index.html
+++ b/proyectos/NaranjasDelTuria/index.html
@@ -42,15 +42,15 @@
   <h3 class="section-title">Productos destacados</h3>
   <div class="grid cards">
     <article class="card">
-      <img src="https://images.unsplash.com/photo-1542444459-db63c9f73396?q=80&w=1200&auto=format&fit=crop" alt="Naranjas de mesa">
+      <img src="https://cdn.pixabay.com/photo/2016/11/29/05/04/oranges-1867158_1280.jpg" alt="Cestas con naranjas de mesa">
       <div class="pad"><h3>Naranjas de mesa</h3><p>Dulces y aromáticas, perfectas para comer.</p></div>
     </article>
     <article class="card">
-      <img src="https://images.unsplash.com/photo-1547514701-42782101795e?q=80&w=1200&auto=format&fit=crop" alt="Naranjas de zumo">
+      <img src="https://cdn.pixabay.com/photo/2016/11/21/16/29/oranges-1845353_1280.jpg" alt="Naranjas listas para zumo">
       <div class="pad"><h3>Naranjas de zumo</h3><p>Misma calidad con piel más pequeña, ideales para exprimir.</p></div>
     </article>
     <article class="card">
-      <img src="https://images.unsplash.com/photo-1534088568595-a066f410bcda?q=80&w=1200&auto=format&fit=crop" alt="Mandarinas">
+      <img src="https://cdn.pixabay.com/photo/2016/01/19/17/17/mandarins-1150013_1280.jpg" alt="Mandarinas recién recolectadas">
       <div class="pad"><h3>Mandarinas</h3><p>Clementinas muy dulces, fáciles de pelar.</p></div>
     </article>
   </div>

--- a/proyectos/NaranjasDelTuria/noticias.html
+++ b/proyectos/NaranjasDelTuria/noticias.html
@@ -26,15 +26,15 @@
 <main class="container">
 <h2 class="section-title">Noticias</h2>
 <div class="grid cards">
-  <article class="card"><img src="https://images.unsplash.com/photo-1617093727343-374698b1b08f?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2018/05/04/21/26/orange-3374495_1280.jpg" alt="Naranjas brillantes recién cortadas"><div class="pad">
     <h3>Abril: ¡Seguimos con naranjas!</h3>
     <p>Navel Lane Late, dulces y con mucho zumo.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1617093727343-374698b1b08f?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/08/06/10/16/orange-2593750_1280.jpg" alt="Ramas de naranjos con fruta"><div class="pad">
     <h3>Inicio temporada</h3>
     <p>Abierto el pedido desde noviembre.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1617093727343-374698b1b08f?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2019/11/21/13/06/oranges-4641659_1280.jpg" alt="Cajas de cítricos en el campo"><div class="pad">
     <h3>Limones de enero</h3>
     <p>Perfectos para tu cocina.</p>
   </div></article>

--- a/proyectos/NaranjasDelTuria/pedidos.html
+++ b/proyectos/NaranjasDelTuria/pedidos.html
@@ -24,7 +24,7 @@
 </header>
 <main class="container">
 <h2 class="section-title">Hacer un Pedido</h2>
-<img src="https://images.unsplash.com/photo-1534088568595-a066f410bcda?q=80&w=1200&auto=format&fit=crop" alt="" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
+<img src="https://cdn.pixabay.com/photo/2017/10/10/21/49/orange-2838089_1280.jpg" alt="Camino entre naranjos con cajas de cosecha" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
 <p>Elige el canal que prefieras:</p>
 <ul>
   <li><strong>WhatsApp:</strong> <a href="https://wa.me/34658882907" target="_blank" rel="noopener">658 882 907</a></li>

--- a/proyectos/NaranjasDelTuria/precios.html
+++ b/proyectos/NaranjasDelTuria/precios.html
@@ -25,7 +25,7 @@
 
 <main class="container">
 <section class="prices">
-  <img src="https://images.unsplash.com/photo-1542444459-db63c9f73396?q=80&w=1200&auto=format&fit=crop" alt="" style="width:100%;height:200px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
+  <img src="https://cdn.pixabay.com/photo/2018/04/10/16/19/orange-tree-3300711_1280.jpg" alt="Filas de naranjos en el campo" style="width:100%;height:200px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
   <h2 class="section-title">Precios</h2>
   <p class="subtle">Transporte incluido en todos los precios.</p>
   <table>

--- a/proyectos/NaranjasDelTuria/recetas.html
+++ b/proyectos/NaranjasDelTuria/recetas.html
@@ -27,19 +27,19 @@
 <h2 class="section-title">Recetas con Naranja</h2>
 <p class="subtle">Ideas dulces y saladas con cítricos de Valencia.</p>
 <div class="grid cards">
-  <article class="card"><img src="https://images.unsplash.com/photo-1541782814459-bb2af2f05b55?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/03/16/09/51/orange-jam-2147452_1280.jpg" alt="Tarro de mermelada de naranja casera"><div class="pad">
     <h3>Mermelada ligera de naranja</h3>
     <p>Con piel confitada y toque de limón.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1541782814459-bb2af2f05b55?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/05/15/12/48/cake-2313450_1280.jpg" alt="Tarta con rodajas de naranja"><div class="pad">
     <h3>Tarta de queso con naranja</h3>
     <p>Base crujiente y crema cítrica.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1541782814459-bb2af2f05b55?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/07/25/09/25/salad-2539647_1280.jpg" alt="Ensalada templada con pollo y naranja"><div class="pad">
     <h3>Pollo glaseado a la naranja</h3>
     <p>Salado con un punto dulce.</p>
   </div></article>
-  <article class="card"><img src="https://images.unsplash.com/photo-1541782814459-bb2af2f05b55?q=80&w=1200&auto=format&fit=crop" alt=""><div class="pad">
+  <article class="card"><img src="https://cdn.pixabay.com/photo/2017/05/11/21/13/cake-2305192_1280.jpg" alt="Bizcocho glaseado con mandarina"><div class="pad">
     <h3>Bizcocho húmedo de mandarina</h3>
     <p>Aceite de oliva y ralladura.</p>
   </div></article>

--- a/proyectos/NaranjasDelTuria/regala.html
+++ b/proyectos/NaranjasDelTuria/regala.html
@@ -25,7 +25,7 @@
 
 <main class="container">
 <h2 class="section-title">Regala Naranjas</h2>
-<img src="https://images.unsplash.com/photo-1606768666853-403c90a981ad?q=80&w=1200&auto=format&fit=crop" alt="" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
+<img src="https://cdn.pixabay.com/photo/2018/03/06/10/55/orange-3202529_1280.jpg" alt="Caja de naranjas lista para regalo" style="width:100%;height:220px;object-fit:cover;border-radius:12px;box-shadow:var(--shadow);margin-bottom:12px">
 <p>Un detalle con todo el sabor y la frescura de Valencia. Personalizamos la caja y la enviamos en 24h.</p>
 <ul>
   <li>Tarjeta de felicitación con tu mensaje.</li>

--- a/proyectos/NaranjasDelTuria/style.css
+++ b/proyectos/NaranjasDelTuria/style.css
@@ -32,7 +32,7 @@ a:hover{text-decoration:underline}
 .nav a{color:#fff;font-weight:700}
 .cta-top{background:#fff;color:var(--brand);padding:8px 14px;border-radius:999px;font-weight:800}
 .hero{color:#fff;padding:0;text-align:center;background:#111}
-.hero .img{width:100%; height:min(70vh, 720px); background:url('https://images.unsplash.com/photo-1542831371-29b0f74f9713?q=80&w=1600&auto=format&fit=crop') center/cover no-repeat;}
+.hero .img{width:100%; height:min(70vh, 720px); background:url('https://cdn.pixabay.com/photo/2016/11/29/05/08/orange-grove-1867168_1280.jpg') center/cover no-repeat;}
 .hero .overlay{position:relative; margin-top:-48vh; padding:24px}
 .hero .overlay .cta{display:inline-block;background:var(--brand);color:#fff;padding:12px 20px;border-radius:12px;font-weight:800;box-shadow:var(--shadow)}
 .hero h1{font-size:44px;line-height:1.1;margin:0 0 12px;text-shadow:0 3px 20px rgba(0,0,0,.35)}


### PR DESCRIPTION
## Summary
- sustituí todas las imágenes de la sección NaranjasDelTuria por fotografías de naranjos, cosechas y productos cítricos
- añadí descripciones alternativas acordes al nuevo material gráfico para mejorar el contexto visual
- actualicé la imagen de cabecera para mostrar un campo de naranjos acorde con la marca

## Testing
- no se ejecutaron pruebas (cambios sólo de contenido estático)


------
https://chatgpt.com/codex/tasks/task_e_68de95d3744c8330a40d5b680dc428d7